### PR TITLE
Added Unit Test for semicolon counting & public static Map for Variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,18 @@
             <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing -->
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.18</artifactId>
             <version>1.24.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>cassandra-all</artifactId>
+            <version>0.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/we/are/project/cipher/InfiniteCode.java
+++ b/src/main/java/we/are/project/cipher/InfiniteCode.java
@@ -6,7 +6,9 @@ import org.bukkit.command.CommandMap;
 import org.bukkit.command.CommandSender;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**Made by Ik#2932, This has limited uses but is really useful to save on lines!*/ public class InfiniteCode { /**Runnables in, Output out*/ public static Object run(ArgRunnable... args) throws Exception {Object result = null;for (ArgRunnable arg : args) result = arg.run(result);return result;}
@@ -14,4 +16,5 @@ import java.util.Optional;
     private static CommandMap map = null;
     public static Object whilst(ArgRunnable condition, ArgRunnable exec, ArgRunnable fail) throws Exception {Object lastExec = null; while(run(condition) != null && (lastExec = run(exec)) != null); return lastExec == null ? run(fail) : lastExec;}
     public static boolean registerCommand(String name, String desc, String usage, List<String> aliases, ArgRunnable runnable) throws Exception {return run(e -> map == null ? map = (CommandMap) run(empty -> Bukkit.getServer().getClass().getDeclaredField("commandMap"), field -> run(empty -> InfiniteCode.runVoid(() -> ((Field)field).setAccessible(true)), empty -> ((Field)field).get(Bukkit.getServer()))) : null, e -> map.register(name, new Command(name, desc, usage, Optional.ofNullable(aliases).orElse(List.of())) {@Override public boolean execute(CommandSender commandSender, String s, String[] strings) {try {return run(e -> runnable.run(new Object[]{commandSender, strings})) != null;} catch (Exception ignored) {} return false;}})) != null;}
+    /*Public Map for variables. Allows setting variables without semicolons*/public static final Map<String,Object> VARIABLES = new HashMap<>();
 }

--- a/src/test/java/we/are/project/cipher/BukkitTests.java
+++ b/src/test/java/we/are/project/cipher/BukkitTests.java
@@ -4,7 +4,6 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntitySpawnEvent;
@@ -16,7 +15,7 @@ import org.junit.jupiter.api.TestInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AllTests {
+public class BukkitTests {
 
     static final ServerMock serverMock = MockBukkit.mock();
     ProjectCipher plugin;

--- a/src/test/java/we/are/project/cipher/FileTests.java
+++ b/src/test/java/we/are/project/cipher/FileTests.java
@@ -1,0 +1,82 @@
+package we.are.project.cipher;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FileTests {
+
+    private static final String REGEX_PACKAGE = "^package [A-Za-z0-9\\.]+;$";
+    private static final String REGEX_IMPORT = "^import [A-Za-z0-9\\.\\*]+;$";
+    private static final String REGEX_EMPTY = "^\\w*$";
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileTests.class);
+    File sourcesRoot = new File(System.getProperty("user.dir"), "src" + File.separator + "main" + File.separator + "java");
+    Map<File, List<String>> source = new HashMap<>();
+
+    @BeforeAll
+    public void readSourceFiles() throws IOException {
+        LOGGER.debug("Loading source code in " + sourcesRoot.getAbsolutePath());
+        Files.walk(sourcesRoot.toPath()).filter(path -> {
+            if (!Files.isRegularFile(path)) return false;
+            return path.toFile().getName().endsWith(".java");
+        }).forEach(path -> {
+            File file = path.toFile();
+            List<String> lines;
+            try {
+                lines = readLines(file);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            source.put(file, lines);
+            LOGGER.debug("Read " + lines.size() + " lines from file " + file.getAbsolutePath());
+        });
+    }
+
+    private static List<String> readLines(File file) throws IOException {
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+            return bufferedReader.lines().collect(Collectors.toList());
+        }
+    }
+
+    @Test
+    public void countSemicolons() {
+        for (Map.Entry<File, List<String>> entry : source.entrySet()) {
+            File file = entry.getKey();
+            List<String> lines = entry.getValue();
+            List<Map.Entry<String, Integer>> perLine = new ArrayList<>();
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                if (isIgnoredLine(line)) continue;
+                int semicolons = getSemicolons(line);
+                String linePath = file.getAbsolutePath().replace(System.getProperty("user.dir"),"") + ":" + (i + 1);
+                assert semicolons < 4 : linePath + " contains " + semicolons + " semicolons";
+                perLine.add(new AbstractMap.SimpleEntry<>(linePath, semicolons));
+            }
+            perLine = perLine.stream().filter(line -> line.getValue() > 0).collect(Collectors.toList());
+            if (!perLine.isEmpty()) perLine.remove(perLine.size() - 1);
+            perLine.forEach(line -> {
+                if (line.getValue() < 3) {
+                    LOGGER.warn(line.getKey() + " only uses " + line.getValue() + " semicolons, could be more.");
+                }
+            });
+        }
+    }
+
+    private static boolean isIgnoredLine(String line) {
+        return line.matches(REGEX_IMPORT) || line.matches(REGEX_PACKAGE) || line.matches(REGEX_EMPTY);
+    }
+
+    private static int getSemicolons(String string) {
+        return (int) string.chars().filter(value -> ((char) value) == ';').count();
+    }
+
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=[%p] %m%n


### PR DESCRIPTION
Throws AssertionError for lines with more than 3 semicolons, and a warning for lines with less than 3 semicolons, unless it's the last line to contain any semicolons.

Example Output:

```
[INFO] Running we.are.project.cipher.FileTests
[WARN] \src\main\java\we\are\project\cipher\ProjectCipher.java:34 only uses 2 semicolons, could be more.
[WARN] \src\main\java\we\are\project\cipher\InfiniteCode.java:14 only uses 1 semicolons, could be more.
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in we.are.project.cipher.FileTests
```

It also adds a `public static final Map<String,Object> VARIABLES` in InfiniteCode to allow setting variables without needing semicolons.